### PR TITLE
Update upstream repository references and replacement mechanism

### DIFF
--- a/.github/scripts/Invoke-ContentReplacer.ps1
+++ b/.github/scripts/Invoke-ContentReplacer.ps1
@@ -1,0 +1,6 @@
+$readmeRaw = Get-Content 'README.md'
+$readmeRaw -replace '## mission', "| :arrows_counterclockwise: | This repo is a mirror of the open source [AzGovViz project](https://github.com/JulianHayward/Azure-MG-Sub-Governance-Reporting) maintained by Julian Hayward, other Microsoft employees, and community members. It is mirrored here with his permission, and this mirror strives to stay in sync with released upstream versions. Please consider making product improvement recommendations on the upstream repo to prevent divergence. Thank you. |`n|-----------|:--------------------------|`n`n## Mission" | Set-Content 'README.md'
+Write-Host 'README.md has been updated with block for upstream notice.'
+
+Set-Content 'SUPPORT.md' "# Support`n`nThis project uses GitHub Issues to track bugs and feature requests. Please search the existing issues before filing new issues to avoid duplicates.`n`n## Upstream reporting`n`nAs this repo is largely a mirror of this [upstream repository](https://github.com/JulianHayward/Azure-MG-Sub-Governance-Reporting), consider opening your issue there to ensure changes are made in the root project."
+Write-Host 'SUPPORT.md has been updated with block for upstream notice.'

--- a/.github/workflows/upstream-release-checker.yml
+++ b/.github/workflows/upstream-release-checker.yml
@@ -21,7 +21,6 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-
       - uses: tibdex/github-app-token@v1
         id: generate-token
         with:
@@ -66,10 +65,16 @@ jobs:
       - name: Find and Replace Upstream Repo With This Repo
         uses: jacobtomlinson/gha-find-replace@v3
         with:
-          find: 'JulianHayward/Azure-MG-Sub-Governance-Reporting'
-          replace: 'Azure/Azure-Governance-Visualizer'
+          find: "JulianHayward/Azure-MG-Sub-Governance-Reporting"
+          replace: "Azure/Azure-Governance-Visualizer"
           regex: false
-          exclude: '**/.github/workflows/upstream-release-checker.yml'
+          exclude: "**/.github/workflows/upstream-release-checker.yml"
+
+      - name: Check for upstream release and pull if available
+        shell: pwsh
+        run: |
+          .github/scripts/Invoke-ContentReplacer.ps1
+        working-directory: ${{ github.repository }}
 
       - name: Check for changes
         id: git_status

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ The technical requirements as well as the required permissions are minimal.
 
 You can run the script either for your tenant root management group or any other management group.
 
+| :arrows_counterclockwise: | This repo is a mirror of the open source [AzGovViz project](https://github.com/JulianHayward/Azure-MG-Sub-Governance-Reporting) maintained by Julian Hayward, other Microsoft employees, and community members. It is mirrored here with his permission, and this mirror strives to stay in sync with released upstream versions. Please consider making product improvement recommendations on the upstream repo to prevent divergence. Thank you. |
+|-----------|:--------------------------|
+
 ## Mission
 
 "_Governance can be a complex thing_.."

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,25 +1,7 @@
-# TODO: The maintainer of this repo has not yet edited this file
-
-**REPO OWNER**: Do you want Customer Service & Support (CSS) support for this product/project?
-
-- **No CSS support:** Fill out this template with information about how to file issues and get help.
-- **Yes CSS support:** Fill out an intake form at [aka.ms/onboardsupport](https://aka.ms/onboardsupport). CSS will work with/help you to determine next steps.
-- **Not sure?** Fill out an intake as though the answer were "Yes". CSS will help you decide.
-
-*Then remove this first heading from this SUPPORT.MD file before publishing your repo.*
-
 # Support
 
-## How to file issues and get help  
+This project uses GitHub Issues to track bugs and feature requests. Please search the existing issues before filing new issues to avoid duplicates.
 
-This project uses GitHub Issues to track bugs and feature requests. Please search the existing 
-issues before filing new issues to avoid duplicates.  For new issues, file your bug or 
-feature request as a new Issue.
+## Upstream reporting
 
-For help and questions about using this project, please **REPO MAINTAINER: INSERT INSTRUCTIONS HERE 
-FOR HOW TO ENGAGE REPO OWNERS OR COMMUNITY FOR HELP. COULD BE A STACK OVERFLOW TAG OR OTHER
-CHANNEL. WHERE WILL YOU HELP PEOPLE?**.
-
-## Microsoft Support Policy  
-
-Support for this **PROJECT or PRODUCT** is limited to the resources listed above.
+As this repo is largely a mirror of this [upstream repository](https://github.com/JulianHayward/Azure-MG-Sub-Governance-Reporting), consider opening your issue there to ensure changes are made in the root project.


### PR DESCRIPTION
This pull request includes changes primarily aimed at reflecting the mirror status of the repository and providing instructions for upstream reporting. The most significant changes are the addition of upstream notices in the `README.md` and `SUPPORT.md` files, the modification of a GitHub workflow file to include a script for content replacement, and the replacement of a repository name in the same workflow file.

Upstream notice additions:

* [`.github/scripts/Invoke-ContentReplacer.ps1`](diffhunk://#diff-469c1f1945846c93a228f66b46a0dabb77f02b9b12f82d7cfea948eeeec052bdR1-R6): A script was added that updates the `README.md` and `SUPPORT.md` files with blocks for upstream notices.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R17-R19): An upstream notice block was added to inform users that the repository is a mirror of an open-source project and to direct them to make product improvement recommendations on the upstream repository.

* [`SUPPORT.md`](diffhunk://#diff-c5fe610b0215b144474106251cab954f8af55fe26cbd5d2265fd6ca19109c97bL1-R7): The file was updated to include instructions for upstream reporting and to remove the previous placeholder content.

GitHub workflow modifications:

* [`.github/workflows/upstream-release-checker.yml`](diffhunk://#diff-a6cb93f0679b42eba8d17077985a34cb9b992baad381dca96a2ce50c2227b065L24): The workflow was updated to include the execution of the `Invoke-ContentReplacer.ps1` script and to replace the repository name in the "Find and Replace Upstream Repo With This Repo" step. [[1]](diffhunk://#diff-a6cb93f0679b42eba8d17077985a34cb9b992baad381dca96a2ce50c2227b065L24) [[2]](diffhunk://#diff-a6cb93f0679b42eba8d17077985a34cb9b992baad381dca96a2ce50c2227b065L69-R77)