### PR TITLE
fix: Error: "An invalid IP address was specified."

### DIFF
--- a/pwsh/AzGovVizParallel.ps1
+++ b/pwsh/AzGovVizParallel.ps1
@@ -9781,7 +9781,8 @@ function processNetwork {
                     $subnetNetOutput = $arr
                 }
 
-                $Mask = $AddressPrefix.substring($AddressPrefix.Length - 2, 2)
+                # Extract mask properly to handle both single and double digit prefixes
+                $Mask = ($AddressPrefix -split '/')[-1]
 
                 #Amount of available IP Addresses minus the 3 IPs that Azure consumes, minus net and broadcast
                 #https://learn.microsoft.com/azure/virtual-network/virtual-networks-faq#are-there-any-restrictions-on-using-ip-addresses-within-these-subnets
@@ -9821,13 +9822,28 @@ function processNetwork {
                 #endregion IP address usage
 
                 $subnetPrefix = $AddressPrefix -replace '.*/'
-
-                $subnetmask = ([IPAddress]"$([system.convert]::ToInt64(('1'*$subnetPrefix).PadRight(32,'0'),2))").IPAddressToString
-                $IPBits = [int[]]$subnetNet.Split('.')
-                $MaskBits = [int[]]$subnetmask.Split('.')
-                $NetworkIDBits = 0..3 | ForEach-Object { $IPBits[$_] -band $MaskBits[$_] }
-                $Broadcast = (0..3 | ForEach-Object { $NetworkIDBits[$_] + ($MaskBits[$_] -bxor 255) }) -join '.'
-                $Range = "$subnetNet - $Broadcast"
+                
+                # Validate subnet prefix to prevent IP address conversion errors
+                if ([string]::IsNullOrWhiteSpace($subnetPrefix) -or $subnetPrefix -eq '-1' -or $subnetPrefix -notmatch '^\d+$' -or [int]$subnetPrefix -lt 0 -or [int]$subnetPrefix -gt 32) {
+                    Write-Warning "Invalid subnet prefix '$subnetPrefix' for address prefix '$AddressPrefix'. Skipping subnet mask calculation."
+                    $subnetmask = "Invalid"
+                    $Range = "Invalid"
+                }
+                else {
+                    try {
+                        $subnetmask = ([IPAddress]"$([system.convert]::ToInt64(('1'*$subnetPrefix).PadRight(32,'0'),2))").IPAddressToString
+                        $IPBits = [int[]]$subnetNet.Split('.')
+                        $MaskBits = [int[]]$subnetmask.Split('.')
+                        $NetworkIDBits = 0..3 | ForEach-Object { $IPBits[$_] -band $MaskBits[$_] }
+                        $Broadcast = (0..3 | ForEach-Object { $NetworkIDBits[$_] + ($MaskBits[$_] -bxor 255) }) -join '.'
+                        $Range = "$subnetNet - $Broadcast"
+                    }
+                    catch {
+                        Write-Warning "Failed to calculate subnet mask for prefix '$subnetPrefix' and address '$AddressPrefix': $($_.Exception.Message)"
+                        $subnetmask = "Error"
+                        $Range = "Error"
+                    }
+                }
 
                 $null = $script:arraySubnets.Add([PSCustomObject]@{
                         SubscriptionName                  = $subscriptionName

--- a/pwsh/dev/functions/processNetwork.ps1
+++ b/pwsh/dev/functions/processNetwork.ps1
@@ -376,7 +376,8 @@
                     $subnetNetOutput = $arr
                 }
 
-                $Mask = $AddressPrefix.substring($AddressPrefix.Length - 2, 2)
+                # Extract mask properly to handle both single and double digit prefixes
+                $Mask = ($AddressPrefix -split '/')[-1]
 
                 #Amount of available IP Addresses minus the 3 IPs that Azure consumes, minus net and broadcast
                 #https://learn.microsoft.com/azure/virtual-network/virtual-networks-faq#are-there-any-restrictions-on-using-ip-addresses-within-these-subnets
@@ -416,13 +417,28 @@
                 #endregion IP address usage
 
                 $subnetPrefix = $AddressPrefix -replace '.*/'
-
-                $subnetmask = ([IPAddress]"$([system.convert]::ToInt64(('1'*$subnetPrefix).PadRight(32,'0'),2))").IPAddressToString
-                $IPBits = [int[]]$subnetNet.Split('.')
-                $MaskBits = [int[]]$subnetmask.Split('.')
-                $NetworkIDBits = 0..3 | ForEach-Object { $IPBits[$_] -band $MaskBits[$_] }
-                $Broadcast = (0..3 | ForEach-Object { $NetworkIDBits[$_] + ($MaskBits[$_] -bxor 255) }) -join '.'
-                $Range = "$subnetNet - $Broadcast"
+                
+                # Validate subnet prefix to prevent IP address conversion errors
+                if ([string]::IsNullOrWhiteSpace($subnetPrefix) -or $subnetPrefix -eq '-1' -or $subnetPrefix -notmatch '^\d+$' -or [int]$subnetPrefix -lt 0 -or [int]$subnetPrefix -gt 32) {
+                    Write-Warning "Invalid subnet prefix '$subnetPrefix' for address prefix '$AddressPrefix'. Skipping subnet mask calculation."
+                    $subnetmask = "Invalid"
+                    $Range = "Invalid"
+                }
+                else {
+                    try {
+                        $subnetmask = ([IPAddress]"$([system.convert]::ToInt64(('1'*$subnetPrefix).PadRight(32,'0'),2))").IPAddressToString
+                        $IPBits = [int[]]$subnetNet.Split('.')
+                        $MaskBits = [int[]]$subnetmask.Split('.')
+                        $NetworkIDBits = 0..3 | ForEach-Object { $IPBits[$_] -band $MaskBits[$_] }
+                        $Broadcast = (0..3 | ForEach-Object { $NetworkIDBits[$_] + ($MaskBits[$_] -bxor 255) }) -join '.'
+                        $Range = "$subnetNet - $Broadcast"
+                    }
+                    catch {
+                        Write-Warning "Failed to calculate subnet mask for prefix '$subnetPrefix' and address '$AddressPrefix': $($_.Exception.Message)"
+                        $subnetmask = "Error"
+                        $Range = "Error"
+                    }
+                }
 
                 $null = $script:arraySubnets.Add([PSCustomObject]@{
                         SubscriptionName                  = $subscriptionName


### PR DESCRIPTION
This pull request improves the robustness and accuracy of subnet mask extraction and calculation in both `AzGovVizParallel.ps1` and `processNetwork.ps1`. The main focus is on correctly handling subnet prefixes, validating input, and providing better error handling to prevent runtime issues during IP address calculations.

**Subnet mask extraction and validation improvements:**

* Updated the method for extracting the subnet mask from `AddressPrefix` to correctly handle both single and double digit prefixes using a split operation instead of substring, making the code more reliable. [[1]](diffhunk://#diff-fd477ce2ef0be887b7d36b1973b8e695706e166f09be5f485b9d99a6c378f9d4L9784-R9785) [[2]](diffhunk://#diff-d31c83cb3665b25dfb2b1db11954b61681af7abe53b59081414ce0cbd476769bL379-R380)
* Added validation for the extracted subnet prefix to ensure it is a valid integer between 0 and 32. If the prefix is invalid, the code now logs a warning and skips subnet mask calculation, preventing potential errors. [[1]](diffhunk://#diff-fd477ce2ef0be887b7d36b1973b8e695706e166f09be5f485b9d99a6c378f9d4R9826-R9846) [[2]](diffhunk://#diff-d31c83cb3665b25dfb2b1db11954b61681af7abe53b59081414ce0cbd476769bR421-R441)

**Error handling enhancements:**

* Wrapped the subnet mask calculation logic in a try-catch block. If an exception occurs (e.g., due to invalid input), a warning is logged and the subnet mask and range are set to "Error", improving the script's resilience. [[1]](diffhunk://#diff-fd477ce2ef0be887b7d36b1973b8e695706e166f09be5f485b9d99a6c378f9d4R9826-R9846) [[2]](diffhunk://#diff-d31c83cb3665b25dfb2b1db11954b61681af7abe53b59081414ce0cbd476769bR421-R441)