### PR TITLE
fix: handle retired classicAdministrators API (InvalidResourceType 404)

### DIFF
--- a/pwsh/AzGovVizParallel.ps1
+++ b/pwsh/AzGovVizParallel.ps1
@@ -35801,10 +35801,11 @@ function dataCollectionClassicAdministratorsSub {
         method                 = 'GET'
         currentTask            = "classicAdministrators '$($scopeDisplayName)' ('$scopeId') [quotaId:'$subscriptionQuotaId']"
         AzAPICallConfiguration = $azAPICallConf
+        unhandledErrorAction   = 'ContinueQuiet'
     }
 
     $AzApiCallResult = AzAPICall @azAPICallPayload
-    if ($AzApiCallResult -ne 'ClassicAdministratorListFailed') {
+    if ($AzApiCallResult -ne 'ClassicAdministratorListFailed' -and $AzApiCallResult -ne 'InvalidResourceType') {
         $arrayClassicAdministrators = [System.Collections.ArrayList]@()
         foreach ($roleAll in $AzApiCallResult) {
             $splitPropertiesRole = $roleAll.properties.role.Split(';')

--- a/pwsh/dev/functions/dataCollection/dataCollectionFunctions.ps1
+++ b/pwsh/dev/functions/dataCollection/dataCollectionFunctions.ps1
@@ -4204,10 +4204,11 @@ function dataCollectionClassicAdministratorsSub {
         method                 = 'GET'
         currentTask            = "classicAdministrators '$($scopeDisplayName)' ('$scopeId') [quotaId:'$subscriptionQuotaId']"
         AzAPICallConfiguration = $azAPICallConf
+        unhandledErrorAction   = 'ContinueQuiet'
     }
 
     $AzApiCallResult = AzAPICall @azAPICallPayload
-    if ($AzApiCallResult -ne 'ClassicAdministratorListFailed') {
+    if ($AzApiCallResult -ne 'ClassicAdministratorListFailed' -and $AzApiCallResult -ne 'InvalidResourceType') {
         $arrayClassicAdministrators = [System.Collections.ArrayList]@()
         foreach ($roleAll in $AzApiCallResult) {
             $splitPropertiesRole = $roleAll.properties.role.Split(';')


### PR DESCRIPTION
## Problem

Microsoft retired Azure classic administrators on **2024-08-31** and the resource type has been fully removed as of May 2026. The endpoint now returns:

```
HTTP 404 Not Found
error.code    : InvalidResourceType
error.message : The resource type could not be found in the namespace
                'Microsoft.Authorization' for api version '2015-07-01'.
```

`dataCollectionClassicAdministratorsSub` called `AzAPICall` without an `unhandledErrorAction` parameter. AzAPICall 1.4.1 treats this unrecognised 404 as `Stop`, which raises a terminating error inside the `-Parallel` ForEach-Object block and **kills the entire run** for all subscriptions in the tenant.

First observed on a CSP subscription (quotaId `CSP_2015-05-01`), but not CSP-specific - the resource type is gone tenant-wide.

## Fix

Two changes to `dataCollectionClassicAdministratorsSub` (in `AzGovVizParallel.ps1` and `dev/functions/dataCollection/dataCollectionFunctions.ps1`):

**1. Add `unhandledErrorAction = 'ContinueQuiet'` to the AzAPICall splat**

Prevents the defunct endpoint from terminating the run. Matches the pattern already used by `getDiagnosticSettingsMg`, storage account calls, and other functions that encounter legitimately absent resource types.

**2. Add `'InvalidResourceType'` to the result guard**

```powershell
# Before
if ($AzApiCallResult -ne 'ClassicAdministratorListFailed') {

# After
if ($AzApiCallResult -ne 'ClassicAdministratorListFailed' -and $AzApiCallResult -ne 'InvalidResourceType') {
```

When the retired API returns `InvalidResourceType`, the subscription is silently skipped and no classic administrators entry is recorded - which is correct since the resource type no longer exists anywhere in Azure.

## Reference

https://learn.microsoft.com/en-us/azure/role-based-access-control/classic-administrators