### PR TITLE
Handle VNet JSON case-collision failures with Resource Graph fallback

### DIFF
--- a/pwsh/AzGovVizParallel.ps1
+++ b/pwsh/AzGovVizParallel.ps1
@@ -31829,9 +31829,42 @@ function dataCollectionVNets {
     $currentTask = "Getting Virtual Networks for Subscription: '$($scopeDisplayName)' ('$scopeId') [quotaId:'$SubscriptionQuotaId']"
     $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/subscriptions/$($scopeId)/providers/Microsoft.Network/virtualNetworks?api-version=2022-05-01"
     $method = 'GET'
-    $networkResult = AzAPICall -AzAPICallConfiguration $azAPICallConf -uri $uri -method $method -currentTask $currentTask -caller 'CustomDataCollection'
 
-    if ($networkResult -eq 'someError') {
+    try {
+        $networkResult = AzAPICall -AzAPICallConfiguration $azAPICallConf -uri $uri -method $method -currentTask $currentTask -caller 'CustomDataCollection' -unhandledErrorAction Continue
+    }
+    catch {
+        Write-Host "[dataCollectionVNets] Primary VNet collection failed for subscription '$scopeDisplayName' ('$scopeId'): $($_.Exception.Message)"
+        Write-Host "[dataCollectionVNets] Trying Resource Graph fallback for subscription '$scopeDisplayName' ('$scopeId')"
+
+        try {
+            $uriResourceGraph = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/providers/Microsoft.ResourceGraph/resources?api-version=2022-10-01"
+            $resourceGraphQuery = @"
+resources
+| where type =~ 'microsoft.network/virtualnetworks'
+| where subscriptionId =~ '$scopeId'
+| project id, name, location, properties
+"@
+            $body = @"
+{
+    "query": "$resourceGraphQuery",
+    "subscriptions": ["$scopeId"],
+    "options": {
+        "`$top": 1000
+    }
+}
+"@
+
+            $networkResult = AzAPICall -AzAPICallConfiguration $azAPICallConf -uri $uriResourceGraph -method 'POST' -body $body -listenOn 'Content' -currentTask "$currentTask (ResourceGraph fallback)" -caller 'CustomDataCollection' -unhandledErrorAction Continue
+            Write-Host "[dataCollectionVNets] Resource Graph fallback succeeded for subscription '$scopeDisplayName' ('$scopeId') and returned $($networkResult.Count) Virtual Networks"
+        }
+        catch {
+            Write-Host "[dataCollectionVNets] Skipping VNet collection for subscription '$scopeDisplayName' ('$scopeId') due to fallback error: $($_.Exception.Message)"
+            $networkResult = 'convertfromJSONError'
+        }
+    }
+
+    if ($networkResult -eq 'someError' -or $networkResult -eq 'convertfromJSONError') {
     }
     else {
         if ($networkResult.Count -gt 0) {

--- a/pwsh/dev/functions/dataCollection/dataCollectionFunctions.ps1
+++ b/pwsh/dev/functions/dataCollection/dataCollectionFunctions.ps1
@@ -232,9 +232,42 @@ function dataCollectionVNets {
     $currentTask = "Getting Virtual Networks for Subscription: '$($scopeDisplayName)' ('$scopeId') [quotaId:'$SubscriptionQuotaId']"
     $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/subscriptions/$($scopeId)/providers/Microsoft.Network/virtualNetworks?api-version=2022-05-01"
     $method = 'GET'
-    $networkResult = AzAPICall -AzAPICallConfiguration $azAPICallConf -uri $uri -method $method -currentTask $currentTask -caller 'CustomDataCollection'
 
-    if ($networkResult -eq 'someError') {
+    try {
+        $networkResult = AzAPICall -AzAPICallConfiguration $azAPICallConf -uri $uri -method $method -currentTask $currentTask -caller 'CustomDataCollection' -unhandledErrorAction Continue
+    }
+    catch {
+        Write-Host "[dataCollectionVNets] Primary VNet collection failed for subscription '$scopeDisplayName' ('$scopeId'): $($_.Exception.Message)"
+        Write-Host "[dataCollectionVNets] Trying Resource Graph fallback for subscription '$scopeDisplayName' ('$scopeId')"
+
+        try {
+            $uriResourceGraph = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/providers/Microsoft.ResourceGraph/resources?api-version=2022-10-01"
+            $resourceGraphQuery = @"
+resources
+| where type =~ 'microsoft.network/virtualnetworks'
+| where subscriptionId =~ '$scopeId'
+| project id, name, location, properties
+"@
+            $body = @"
+{
+    "query": "$resourceGraphQuery",
+    "subscriptions": ["$scopeId"],
+    "options": {
+        "`$top": 1000
+    }
+}
+"@
+
+            $networkResult = AzAPICall -AzAPICallConfiguration $azAPICallConf -uri $uriResourceGraph -method 'POST' -body $body -listenOn 'Content' -currentTask "$currentTask (ResourceGraph fallback)" -caller 'CustomDataCollection' -unhandledErrorAction Continue
+            Write-Host "[dataCollectionVNets] Resource Graph fallback succeeded for subscription '$scopeDisplayName' ('$scopeId') and returned $($networkResult.Count) Virtual Networks"
+        }
+        catch {
+            Write-Host "[dataCollectionVNets] Skipping VNet collection for subscription '$scopeDisplayName' ('$scopeId') due to fallback error: $($_.Exception.Message)"
+            $networkResult = 'convertfromJSONError'
+        }
+    }
+
+    if ($networkResult -eq 'someError' -or $networkResult -eq 'convertfromJSONError') {
     }
     else {
         if ($networkResult.Count -gt 0) {


### PR DESCRIPTION
## Summary\n- make dataCollectionVNets resilient when AzAPICall fails to parse mixed-case JSON keys\n- keep existing ARM call path first\n- add Resource Graph fallback (id, 
ame, location, properties) when ARM parsing fails\n- continue collection for affected subscriptions instead of hard-skipping\n\n## Details\nThis addresses the real-world payload case where key casing collisions (for example Environment vs nvironment) can break JSON conversion in the VNet ARM response.\n\n## Files changed\n- pwsh/AzGovVizParallel.ps1\n- pwsh/dev/functions/dataCollection/dataCollectionFunctions.ps1\n\n## Validation\n- PowerShell parser diagnostics report no errors in changed files\n- change is scoped to VNet collection only