### PR TITLE
Handle classicAdministrators InvalidResourceType as non-fatal

### DIFF
--- a/pwsh/AzGovVizParallel.ps1
+++ b/pwsh/AzGovVizParallel.ps1
@@ -35801,11 +35801,21 @@ function dataCollectionClassicAdministratorsSub {
         method                 = 'GET'
         currentTask            = "classicAdministrators '$($scopeDisplayName)' ('$scopeId') [quotaId:'$subscriptionQuotaId']"
         AzAPICallConfiguration = $azAPICallConf
+        skipOnErrorCode        = 404
+        unhandledErrorAction   = 'Continue'
     }
 
     $AzApiCallResult = AzAPICall @azAPICallPayload
-    if ($AzApiCallResult -ne 'ClassicAdministratorListFailed') {
-        $arrayClassicAdministrators = [System.Collections.ArrayList]@()
+    $arrayClassicAdministrators = [System.Collections.ArrayList]@()
+
+    if (
+        $AzApiCallResult -eq 'InvalidResourceType' -or
+        $AzApiCallResult -eq 'someError' -or
+        $AzApiCallResult -eq 'ClassicAdministratorListFailed'
+    ) {
+        Write-Host "[dataCollectionClassicAdministratorsSub] classicAdministrators endpoint not supported or unavailable for subscription '$scopeDisplayName' ('$scopeId'); continuing with empty result"
+    }
+    else {
         foreach ($roleAll in $AzApiCallResult) {
             $splitPropertiesRole = $roleAll.properties.role.Split(';')
             foreach ($role in $splitPropertiesRole) {
@@ -35819,9 +35829,10 @@ function dataCollectionClassicAdministratorsSub {
                     })
             }
         }
-        $script:htClassicAdministrators.($scopeId) = @{
-            ClassicAdministrators = $arrayClassicAdministrators
-        }
+    }
+
+    $script:htClassicAdministrators.($scopeId) = @{
+        ClassicAdministrators = $arrayClassicAdministrators
     }
 }
 $funcDataCollectionClassicAdministratorsSub = $function:dataCollectionClassicAdministratorsSub.ToString()

--- a/pwsh/dev/functions/dataCollection/dataCollectionFunctions.ps1
+++ b/pwsh/dev/functions/dataCollection/dataCollectionFunctions.ps1
@@ -4204,11 +4204,21 @@ function dataCollectionClassicAdministratorsSub {
         method                 = 'GET'
         currentTask            = "classicAdministrators '$($scopeDisplayName)' ('$scopeId') [quotaId:'$subscriptionQuotaId']"
         AzAPICallConfiguration = $azAPICallConf
+        skipOnErrorCode        = 404
+        unhandledErrorAction   = 'Continue'
     }
 
     $AzApiCallResult = AzAPICall @azAPICallPayload
-    if ($AzApiCallResult -ne 'ClassicAdministratorListFailed') {
-        $arrayClassicAdministrators = [System.Collections.ArrayList]@()
+    $arrayClassicAdministrators = [System.Collections.ArrayList]@()
+
+    if (
+        $AzApiCallResult -eq 'InvalidResourceType' -or
+        $AzApiCallResult -eq 'someError' -or
+        $AzApiCallResult -eq 'ClassicAdministratorListFailed'
+    ) {
+        Write-Host "[dataCollectionClassicAdministratorsSub] classicAdministrators endpoint not supported or unavailable for subscription '$scopeDisplayName' ('$scopeId'); continuing with empty result"
+    }
+    else {
         foreach ($roleAll in $AzApiCallResult) {
             $splitPropertiesRole = $roleAll.properties.role.Split(';')
             foreach ($role in $splitPropertiesRole) {
@@ -4222,9 +4232,10 @@ function dataCollectionClassicAdministratorsSub {
                     })
             }
         }
-        $script:htClassicAdministrators.($scopeId) = @{
-            ClassicAdministrators = $arrayClassicAdministrators
-        }
+    }
+
+    $script:htClassicAdministrators.($scopeId) = @{
+        ClassicAdministrators = $arrayClassicAdministrators
     }
 }
 $funcDataCollectionClassicAdministratorsSub = $function:dataCollectionClassicAdministratorsSub.ToString()


### PR DESCRIPTION
## Summary
- handle classicAdministrators endpoint 404/InvalidResourceType as unsupported instead of fatal
- keep data collection running and record an empty classic administrators set for that subscription
- align behavior in both main and dev data collection paths

## Why
Some environments/subscriptions return:
- InvalidResourceType
- HTTP 404 for /providers/Microsoft.Authorization/classicAdministrators?api-version=2015-07-01

This currently can stop execution due to unhandled error behavior.

## Changes
- add skipOnErrorCode = 404
- add unhandledErrorAction = Continue
- treat InvalidResourceType, someError, and ClassicAdministratorListFailed as non-fatal and continue with empty result

## Files changed
- pwsh/AzGovVizParallel.ps1
- pwsh/dev/functions/dataCollection/dataCollectionFunctions.ps1

## Related
- fixes/addresses Azure-Governance-Visualizer issue #70

## Validation
- PowerShell parser diagnostics report no errors in changed files
